### PR TITLE
Fix typo issue that prevented config from taking effect

### DIFF
--- a/config/my.cnf
+++ b/config/my.cnf
@@ -86,6 +86,8 @@ ssl-cipher=DHE-RSA-AES256-SHA
 ssl-ca=/mysql_keys/ca.pem
 ssl-cert=/mysql_keys/server-cert.pem
 ssl-key=/mysql_keys/server-key.pem
+
+# Set default auth plugin
 default_authentication_plugin=mysql_native_password
 
 #log-error	= /var/log/mysql/error.log

--- a/dist/debian/Dockerfile
+++ b/dist/debian/Dockerfile
@@ -35,8 +35,8 @@ RUN \
 USER root   
 
 ADD ./utilities/datajoint-entrypoint.sh /datajoint-entrypoint.sh
-COPY --chown=mysql:mysql ./config/my.cnf /etc/mysql/mysql.cnf
-RUN chmod g+w /etc/mysql/mysql.cnf
+COPY --chown=mysql:mysql ./config/my.cnf /etc/mysql/my.cnf
+RUN chmod g+w /etc/mysql/my.cnf
 ENTRYPOINT ["/datajoint-entrypoint.sh"]
 CMD ["mysqld"]
 HEALTHCHECK       \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,4 +16,4 @@ services:
       ## persist data across docker-compose up/down
       - ./data:/var/lib/mysql
       ## modify MySQL config
-      # - ./my.cnf:/etc/mysql/my.cnf
+      # - ./config/my.cnf:/etc/mysql/my.cnf


### PR DESCRIPTION
This PR fixes a bug introduced recently that prevented `my.cnf` from being applied properly.